### PR TITLE
Add flwr_run.py and ray job submit prep

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,140 @@
+
 # flower-samples
 
 **Experimental Repository**  
-Samples to scale Flower.ai simulations on a Ray Cluster
+Samples demonstrating how to scale Flower.ai simulations on a Ray Cluster.
+
+---
 
 ## Overview
 
-This repository contains experimental examples demonstrating how to run Flower.ai simulations distributed across multiple nodes and GPUs.
+This repository provides experimental examples showcasing Flower.ai simulations running distributed across multiple nodes and GPUs on a Ray Cluster.
 
-First sample:
+### Current Sample
 
-- Based on the [Flower quickstart PyTorch example](https://github.com/adap/flower/tree/96f996207da7e3147506e4be4fe374cb39243e28/examples/quickstart-pytorch)
+- [`quickstart-pytorch`](quickstart-pytorch): Based on the [Flower quickstart PyTorch example](https://github.com/adap/flower/tree/96f996207da7e3147506e4be4fe374cb39243e28/examples/quickstart-pytorch)
+
+---
+
+## Recommended Versions
+
+⚠️ **Important:**  
+The Ray version used on the application needs to match the Ray Cluster.
+
+- **When setting up a Ray Cluster**: Mind that Flower `0.16.0` simulation [requires Ray `2.31.0`](https://github.com/adap/flower/blob/8ba9db597b0309a7d34c7595d89a92f378733428/pyproject.toml#L80).
+- **For IOG Ray clusters**: Base image for [IOG Ray Cluster](https://cloud.io.net/) is Ray `2.30.0`. Use the customized Flower fork at [IOG-Foundation/flower@iog-ray-cluster-2.30.0](https://github.com/IOG-Foundation/flower/tree/iog-ray-cluster-2.30.0).
+  - besides custom pinned ray version, it includes [minor changes](https://github.com/IOG-Foundation/flower/commits/iog-ray-cluster-2.30.0/) which could be merged to the main repo if it makes sense for the official release, such as [allow ray nodes nodes to have zero resources](https://github.com/IOG-Foundation/flower/commit/10c9bbf7625e0426e0f76bb3a2497c3068b03c3a) and [flag to supress deprecation warning](https://github.com/IOG-Foundation/flower/commit/aeb8279f301d1780cc52739fe90b878817f2f588).
+
+## How to Execute
+
+Samples replicate the original Flower examples with minor adjustments and configured environment dependencies for convenience.
+
+For the example [`quickstart-pytorch`](quickstart-pytorch):
+
+```bash
+git clone https://github.com/IOG-Foundation/flower-samples.git
+cd flower-samples/quickstart-pytorch
+```
+
+### Standard Execution (for Reference)
+
+Assuming you are familiar with the common execution of a Flower simulation and setup as described on the base [readme](quickstart-pytorch/README.md).
+
+For reference, that's a standard execution:
+
+```bash
+flwr run . --run-config "num-server-rounds=5"
+```
+
+### Ray Job Submission
+
+When submitting the script as a Ray Job, there is no need for local dependencies to be installed (except a matching Ray version `2.31.0`). If you want to submit to your local Ray Cluster, include the ray dashboard on your local environment (`pip install ray[default]==2.31.0`).  
+
+```bash
+ray job submit \
+--runtime-env-json '{"working_dir": ".", "pip": "requirements.txt"}' \
+-- flwr run . --run-config "num-server-rounds=5"
+```
+
+**Notes:**
+
+- The `working_dir` is propagated to all Ray nodes.
+- The runtime environment is configured on the worker nodes at submission. Subsequent submissions may leverage the cached environment.
+- Specify the cluster address with `--address` if needed ([Ray Jobs CLI Reference](https://docs.ray.io/en/latest/cluster/running-applications/job-submission/cli.html)).
+- The job command to be executed is defined after `--`.
+
+---
+
+#### Intermediate Script `flwr_run.py`
+
+When using the intermediate script `flwr_run.py` to call the Flower CLI, have it available on `working_dir`. Then:
+
+```bash
+ray job submit \
+--runtime-env-json '{"working_dir": ".", "pip": "requirements.txt"}' \
+-- python flwr_run.py . --run-config "num-server-rounds=5"
+```
+
+As noted, `python flwr_run.py .`  is equivalent to `flwr run . `. All Flower simulation arguments are directly forwarded.
+
+🔧 **Purpose of `flwr_run.py`:**  
+Use this script to execute custom code or configurations prior to invoking `flwr run`. Modify it if your simulation needs specific environment setups, dynamic parameters, or pre-processing tasks not directly supported by Flower CLI. Possible applications: trigger in advance cluster autoscaling based on the request, as flower simulation will define the distribution based on the resources which are already available; evaluate the request to tune/adapt the resources when passing to the Flower CLI, as some configurations combination (of clients resources and number of supernodes) might allocate resources which will be blocked on wait, setting a sequential undesired pipeline, specially if resources available are much superior than the number of num-supernodes configured.
+
+---
+
+#### For Conda env
+
+To use conda as the base environment:
+
+```bash
+ray job submit \
+--runtime-env-json '{"working_dir": ".", "conda": "conda-env.yml"}' \
+-- flwr run . --run-config "num-server-rounds=5"
+```
+
+---
+
+### IOG Ray Cluster Job Submission
+
+Dependencies below use customized Flower fork at [IOG-Foundation/flower/iog-ray-cluster-2.30.0](https://github.com/IOG-Foundation/flower/tree/iog-ray-cluster-2.30.0).
+
+From VSCode on your [IOG Ray Cluster](https://cloud.io.net/), set up authentication header once:
+
+```bash
+export RAY_JOB_HEADERS="{\"Authorization\": \"Basic $(echo -n ':'$PASSWORD_ENV | base64)\"}"
+```
+
+Submit your Flower simulation job:
+
+```bash
+ray job submit \
+--runtime-env-json '{"working_dir": ".", "pip": "requirements-iog.txt"}' \
+-- flwr run . simulation-gpu-1000 --run-config "num-server-rounds=5"
+```
+
+For base conda env:
+
+```bash
+ray job submit \
+--runtime-env-json '{"working_dir": ".", "conda": "conda-env-iog.yml"}' \
+-- flwr run . simulation-gpu-1000 --run-config "num-server-rounds=5"
+```
+
+To turn on the `FLWR_SUPRESS_DEPRECATION_WARNINGS` flag:
+
+```bash
+ray job submit \
+--runtime-env-json '{"working_dir": ".", "conda": "conda-env-iog.yml"}' \
+-- FLWR_SUPRESS_DEPRECATION_WARNINGS=true flwr run . simulation-gpu-1000 --run-config "num-server-rounds=5"
+```
+
+## Troubleshooting
+
+- **Version mismatch errors**: Ensure Ray versions match exactly between your local and cluster environments.
+- **Dependency errors (IOG cluster)**: Verify you're using the correct customized Flower version (`iog-ray-cluster-2.30.0`).
+
+---
+
+## Contributions
+
+This repository welcomes contributions. Open an issue or PR if you have suggestions or improvements.

--- a/quickstart-pytorch/README.md
+++ b/quickstart-pytorch/README.md
@@ -6,6 +6,10 @@ framework: [torch, torchvision]
 
 # Federated Learning with PyTorch and Flower (Quickstart Example)
 
+**Note:** Readme as from [Flower quickstart PyTorch example](https://github.com/adap/flower/tree/96f996207da7e3147506e4be4fe374cb39243e28/examples/quickstart-pytorch). For additional context on submitting as Job on a Ray Cluster see [README.md](../README.md)
+
+---
+
 This introductory example to Flower uses PyTorch, but deep knowledge of PyTorch is not necessarily required to run the example. However, it will help you understand how to adapt Flower to your use case. Running this example in itself is quite easy. This example uses [Flower Datasets](https://flower.ai/docs/datasets/) to download, partition and preprocess the CIFAR-10 dataset.
 
 ## Set up the project

--- a/quickstart-pytorch/conda-env-iog.yml
+++ b/quickstart-pytorch/conda-env-iog.yml
@@ -1,0 +1,11 @@
+name: ray-env
+channels:
+  - pytorch
+  - conda-forge
+dependencies:
+  - pytorch=2.5.1
+  - torchvision=0.20.1
+  - pip
+  - pip:
+      - git+https://github.com/IOG-Foundation/flower@iog-ray-cluster-2.30.0
+      - flwr-datasets[vision]

--- a/quickstart-pytorch/conda-env.yml
+++ b/quickstart-pytorch/conda-env.yml
@@ -1,0 +1,12 @@
+name: ray-env
+channels:
+  - pytorch
+  - conda-forge
+dependencies:
+  - pytorch=2.5.1
+  - torchvision=0.20.1
+  - pip
+  - pip:
+      - flwr[simulation]>=1.16.0
+      - flwr-datasets[vision]>=0.5.0
+

--- a/quickstart-pytorch/flwr_run.py
+++ b/quickstart-pytorch/flwr_run.py
@@ -1,0 +1,32 @@
+# To invoke this script, run `ptyhon flwr_run.py .` if you originally intended to run `flwr run .`
+import sys
+from typing import List
+from flwr.cli.app import typer_click_object
+
+def run_with_args(args: List[str] = None):
+    """Run the Flower CLI with the provided arguments."""
+    if args is None:
+        args = sys.argv[1:]
+    
+    # Get the original CLI command object
+    cli = typer_click_object
+    
+    # Call the CLI with provided arguments
+    # This routes to the correct command based on the first argument
+    cli(args, standalone_mode=False)
+
+if __name__ == "__main__":
+
+    # Here you can add any custom logic before running the Flower CLI
+    print("Running Flower Federated Learning Simulation Distributed on a Ray Cluster")
+
+    # Flower run command + all arguments after the script name
+    args = ["run"] + sys.argv[1:]
+
+    try:
+        run_with_args(args)
+    except SystemExit as e:
+        # Handle the system exit that Typer might raise
+        if e.code != 0:
+            print(f"Command failed with exit code {e.code}")
+        sys.exit(e.code)

--- a/quickstart-pytorch/pyproject.toml
+++ b/quickstart-pytorch/pyproject.toml
@@ -41,3 +41,8 @@ options.num-supernodes = 10
 options.num-supernodes = 10
 options.backend.client-resources.num-cpus = 2 # each ClientApp assumes to use 2CPUs
 options.backend.client-resources.num-gpus = 0.2 # at most 5 ClientApp will run in a given GPU
+
+[tool.flwr.federations.simulation-gpu-1000]
+options.num-supernodes = 1000
+options.backend.client-resources.num-cpus = 2
+options.backend.client-resources.num-gpus = 0.2

--- a/quickstart-pytorch/pytorchexample/client_app.py
+++ b/quickstart-pytorch/pytorchexample/client_app.py
@@ -15,7 +15,11 @@ class FlowerClient(NumPyClient):
         self.valloader = valloader
         self.local_epochs = local_epochs
         self.lr = learning_rate
-        self.device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
+        self.device = torch.device(
+            "cuda" if torch.cuda.is_available()
+            else "mps" if torch.backends.mps.is_available()
+            else "cpu"
+        )
 
     def fit(self, parameters, config):
         """Train the model with data of this client."""

--- a/quickstart-pytorch/requirements-iog.txt
+++ b/quickstart-pytorch/requirements-iog.txt
@@ -1,0 +1,7 @@
+git+https://github.com/IOG-Foundation/flower@iog-ray-cluster-2.30.0
+torch==2.5.1
+torchvision==0.20.1
+flwr-datasets[vision]
+datasets==2.14.6
+pyopenssl
+cryptography

--- a/quickstart-pytorch/requirements.txt
+++ b/quickstart-pytorch/requirements.txt
@@ -1,0 +1,4 @@
+flwr[simulation]>=1.16.0
+torch==2.5.1
+torchvision==0.20.1
+flwr-datasets[vision]>=0.5.0


### PR DESCRIPTION
### Notes
- Add ray job submission dependency configurations
- Update Readme on ray job submit to a Ray Cluster
- Add flwr_run.py as an intermediate optional script to execute custom code or configurations prior to invoking `flwr run`
- Update client to use M chips when available

### Testing
- Executed on local Ray Cluster and on [IOG Ray Cluster](https://cloud.io.net/)